### PR TITLE
Contest winner through email

### DIFF
--- a/client/src/helpers/APICalls/sendEmails.ts
+++ b/client/src/helpers/APICalls/sendEmails.ts
@@ -1,19 +1,19 @@
 import { FetchOptions } from '../../interface/FetchOptions';
-import { ProfileApiData } from '../../interface/Profile';
+import { EmailApiData } from '../../interface/Email';
 
 interface Props {
-  profileImage?: string;
-  status?: string;
+  receiverID: string;
+  contestID: string;
 }
 
-export async function updateProfile({ profileImage }: Props): Promise<ProfileApiData> {
+export async function sendWinnerEmail({ receiverID, contestID }: Props): Promise<EmailApiData> {
   const fetchOptions: FetchOptions = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ profileImage, status }),
+    body: JSON.stringify({ receiverID }),
     credentials: 'include',
   };
-  return await fetch(`/users/profile`, fetchOptions)
+  return await fetch(`/contest/${contestID}/winner`, fetchOptions)
     .then((res) => res.json())
     .catch(() => ({
       error: { message: 'Unable to connect to server. Please try again' },

--- a/client/src/interface/Email.ts
+++ b/client/src/interface/Email.ts
@@ -1,0 +1,4 @@
+export interface EmailApiData {
+  error?: { message: string };
+  status?: string;
+}

--- a/server/controllers/sendgrid.js
+++ b/server/controllers/sendgrid.js
@@ -1,0 +1,58 @@
+const asyncHandler = require("express-async-handler");
+const sgMail = require('@sendgrid/mail')
+
+const User = require("../models/User");
+const Contest = require("../models/Contest");
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY)
+
+exports.sendWinnerEmail =  asyncHandler(async (req, res)=> {
+    const userID = req.user.id;
+    const contestID = req.params.id;
+    let success = false;
+    const { receiverID } = req.body;
+    try {
+        const user = await User.findById(userID);
+        const receiver = await User.findById(receiverID);
+        if (!user || !receiver){
+            return res.status(500).json({
+                status: "User not found"
+            })
+        }
+        const contest = await Contest.findById(contestID);
+        if (!contest){
+            return res.status(500).json({
+                status: "Contest not found"
+            })
+        }
+        const msg = {
+            to: receiver.email,
+            from: {
+                name:'TeamVanillaDip',
+                email: 'holuwadanzy@gmail.com',
+            },
+            subject: "Contest Winner",
+            text: `You have been selected a winner in the '${contest.title}'`,
+        }
+        await sgMail
+        .send(msg)
+        .then(() => {
+            console.log('Email sent')
+            success = true;
+        })
+        .catch((error) => {
+            console.error(error)
+        })
+        if (success) {
+            return res.status(200).json({
+                status: 'Email Sent Successfully'
+            })
+        }
+        return res.status(500).json({status: "An error Occured"})
+    } catch (error) {
+        console.error(error)
+        return res.status(500).json({status: "error",
+        error
+        })
+    }
+})

--- a/server/controllers/submission.js
+++ b/server/controllers/submission.js
@@ -1,6 +1,6 @@
 const Submission = require("../models/Submission");
 const Contest = require("../models/Contest");
-const asyncHandler = require("express-async-handler");
+const asyncHandler = require("express-async-handler")
 
 exports.createSubmission = asyncHandler(async (req, res, next) => {
     const userID = req.user.id;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,6 +4,32 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sendgrid/client": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.3.tgz",
+      "integrity": "sha512-tTaHx893w5iqG0sVtUnMyRchuwYF95k4UOkmov1MouMIeMUbNvbalITo7cG7YSXUTY9rT2t4eBY6HcEBCVeqfg==",
+      "requires": {
+        "@sendgrid/helpers": "^7.4.3",
+        "axios": "^0.21.1"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.3.tgz",
+      "integrity": "sha512-Wt+68g1sVEM5UspJh34O/cxtv6BBbtAIk7U9B3PB2ySOtPs9e6hI1QkgYVwpNmkt7k2p86muUNyma/Aig25agg==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.5.tgz",
+      "integrity": "sha512-adXMvrTUOlYr7+UTigZRGSYR9vheBv1y4fF2mugn29NBdQMfcQPGLQ5vIHgSAfcboBFCagZdamZqM5FeSGU0Hw==",
+      "requires": {
+        "@sendgrid/client": "^7.4.3",
+        "@sendgrid/helpers": "^7.4.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -186,6 +212,14 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      }
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "balanced-match": {
@@ -679,6 +713,11 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -965,6 +1004,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "form-data": {
       "version": "2.5.1",

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "dev": "nodemon ./bin/www"
   },
   "dependencies": {
+    "@sendgrid/mail": "^7.4.5",
     "aws-sdk": "^2.949.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",

--- a/server/routes/contest.js
+++ b/server/routes/contest.js
@@ -10,11 +10,14 @@ const {
     getSubmissionByContestId
 } = require("../controllers/contest");
 
+const { sendWinnerEmail } = require("../controllers/sendgrid");
+
 const { createSubmission } = require('../controllers/submission')
 
 // CREATE  
 router.route("/create").post(protect, createContest);
 router.route("/:id/submission").post(protect,createSubmission)
+router.route("/:id/winner").post(protect, sendWinnerEmail)
 
 // READ
 router.route("/:id").get(getContestById);


### PR DESCRIPTION
### What this PR does (required):
- Controller for notifying users when they've won a contest

### Screenshots / Videos (required):
- ![Screenshot (34)](https://user-images.githubusercontent.com/33403043/128292169-69d0e30b-f0ab-4aaf-8d18-850cbde4dcc1.png)


### Any information needed to test this feature (required):
- change directory to the server side
- npm install --save @sendgrid/mail
- Open up postman
- Make a BasicAuth to the server
- Send a post request to http://localhost:3001/contest/<validContestID>/winner

### Any issues with the current functionality (optional):
- Email sends but not delivered on Email server
- This may be due to my account
